### PR TITLE
Fix assigning custom TimeSlot id not working

### DIFF
--- a/lib/Shipment.php
+++ b/lib/Shipment.php
@@ -46,7 +46,7 @@ class Shipment {
                     $details->serialize()
                 );
                 if ($timeslotId !== -1) {
-                    $body['timeslotId'] = $timeslotId;
+                    $body['timeSlotId'] = $timeslotId;
                 }
 
                 break;


### PR DESCRIPTION
Currently when you create a Shipment with a TimeSlot id, the TimeSlot is not used, but a new one is returned instead. This is because the parameter is not correctly spelled.

In https://docs.trunkrs.nl/docs/v1-api-documentation/reference/Trunkrs-Client-API.v1.yaml/paths/~1shipments/post the documentation states that the parameter should be `timeSlotId` with capital S, and not `timeslotId`.