### PR TITLE
Prevent Undefined Properties

### DIFF
--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -21,14 +21,14 @@ class Webhook {
 
     private static function applyV1(Webhook $webhook, $json) {
         $webhook->id = $json->id;
-        $webhook->callbackUrl = $json->url;
+        $webhook->callbackUrl = $json->url ?? '';
         $webhook->sessionHeaderName = $json->key;
         $webhook->sessionToken = $json->token;
         $webhook->uponShipmentCreation = $json->uponShipmentCreation;
         $webhook->uponLabelReady = $json->uponLabelReady;
         $webhook->uponStatusUpdate = $json->uponStatusUpdate;
         $webhook->uponShipmentCancellation = $json->uponShipmentCancellation;
-        $webhook->createdAt = JsonDateTime::from($json->createdAt);
+        $webhook->createdAt = JsonDateTime::from($json->created_at);
     }
 
     /**

--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -21,7 +21,7 @@ class Webhook {
 
     private static function applyV1(Webhook $webhook, $json) {
         $webhook->id = $json->id;
-        $webhook->callbackUrl = $json->url ?? '';
+        $webhook->callbackUrl = $json->url ?? null;
         $webhook->sessionHeaderName = $json->key;
         $webhook->sessionToken = $json->token;
         $webhook->uponShipmentCreation = $json->uponShipmentCreation;

--- a/tests/Mocks/MockV1Responses.php
+++ b/tests/Mocks/MockV1Responses.php
@@ -120,7 +120,7 @@ class MockV1Responses {
             'uponLabelReady' => $actualWebhook->uponLabelReady,
             'uponStatusUpdate' => $actualWebhook->uponStatusUpdate,
             'uponShipmentCancellation' => $actualWebhook->uponShipmentCancellation,
-            'createdAt' => JsonDateTime::to($actualWebhook->createdAt),
+            'created_at' => JsonDateTime::to($actualWebhook->createdAt),
         ];
     }
 


### PR DESCRIPTION
This solves two problems.
1. The json result of the listing of webhooks, doesn't containt an `url `property. See https://docs.trunkrs.nl/docs/v1-api-documentation/reference/Trunkrs-Client-API.v1.yaml/paths/~1webhooks/get. If no url property is set, a default empty string will be used.
2. The json result doesn't containt a `createdAt `property. It's `created_at `poperty. This should solve issue #21 

With these fixes i was able to create, list and delete webhooks (live environment)